### PR TITLE
isSimple fixed for triangles.

### DIFF
--- a/src/hxGeomAlgo/PolyTools.hx
+++ b/src/hxGeomAlgo/PolyTools.hx
@@ -89,6 +89,8 @@ class PolyTools
 	static public function isSimple(poly:Poly):Bool
 	{
 		var len:Int = poly.length;
+		
+		if (len<=3) return true;
 
 		for (i in 0...len) {
 			// first segment


### PR DESCRIPTION
If polygon vertex count is 3 the method incorrectly returned false and detected the polygon as selfintersecting.
